### PR TITLE
Remove bgn requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+include .env
+
 run:
-	export $(grep -v '^#' .env | xargs) > /dev/null
 	go run cmd/main.go
+
+docker:
+	@read -p "enter tag: " tag; \
+	docker build -t quibbble:$$tag -t quibbble:latest -f build/Dockerfile .

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"strings"
@@ -38,7 +37,7 @@ func main() {
 	signal.Notify(stop, syscall.SIGTERM)
 
 	stopped := <-stop
-	logger.Log.Info().Msg(fmt.Sprintf("%s signal received", stopped.String()))
+	logger.Log.Info().Msgf("%s signal received", stopped.String())
 	s.Shutdown(false)
 
 	logger.Log.Info().Msgf("%s service has stopped", service)

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,12 @@ require (
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/justinas/alice v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/quibbble/go-boardgame v1.0.9
+	github.com/quibbble/go-boardgame v1.1.0
 	github.com/quibbble/go-carcassonne v1.1.0
 	github.com/quibbble/go-connect4 v1.0.3
 	github.com/quibbble/go-indigo v1.0.4
 	github.com/quibbble/go-stratego v1.1.1
+	github.com/quibbble/go-tictactoe v1.0.2
 	github.com/quibbble/go-tsuro v1.0.9
 	github.com/rs/zerolog v1.31.0
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/quibbble/go-boardgame v1.0.9 h1:OHoLnLx4FCN7F7AdF7BDWQf96hO/ZOWW1q9tXfi1NZY=
-github.com/quibbble/go-boardgame v1.0.9/go.mod h1:h0aK8LrDTadO/t8ZqwQ8IwNdxyd2wkQAkOXusMtiJHk=
+github.com/quibbble/go-boardgame v1.1.0 h1:ePuY55m1E1giUp0kY6JwglypHpKa89HAtBPAxzzTziE=
+github.com/quibbble/go-boardgame v1.1.0/go.mod h1:AM2N9X5115/wIi1A9spGlALSTEPRjm5ojtng+pKsAgY=
 github.com/quibbble/go-carcassonne v1.1.0 h1:Nu0e6hyy0H4QD6gVd4BdfYxAGIJ9EJQQd6s8T1n4Tvs=
 github.com/quibbble/go-carcassonne v1.1.0/go.mod h1:ipLnQ4sFeGbNm3GpT6o/sR0SSL1v8fP8jHmkKziOks0=
 github.com/quibbble/go-connect4 v1.0.3 h1:N965B1x0Y3ynSdFvm3K8fDAqjKd8ctE84aaA7afCb5g=
@@ -185,6 +185,8 @@ github.com/quibbble/go-indigo v1.0.4 h1:EuwQLlI4upuhYBY+NaVZC9oIj5VAsVgZShDaGwvF
 github.com/quibbble/go-indigo v1.0.4/go.mod h1:maXaFZyYJEw3WHT9naLO10NPce2PjclOWIBE6rbfNNA=
 github.com/quibbble/go-stratego v1.1.1 h1:hPlwpSwha/YYzSEuNoB2zs6rcahMinow+YyNhAeYxYQ=
 github.com/quibbble/go-stratego v1.1.1/go.mod h1:/bBrVs41uz9yLAMqonkqgPTbtYF/9FTF9e/8yEqAE7k=
+github.com/quibbble/go-tictactoe v1.0.2 h1:sLMNzRUUrNSfc9Ew+7750NCmnpgw07/SlTBkyB1nIQ0=
+github.com/quibbble/go-tictactoe v1.0.2/go.mod h1:vNEnRHsBSEnF0Z4DF66J3FrOf2HnNcHW88JbCB4KrU0=
 github.com/quibbble/go-tsuro v1.0.9 h1:mkBsIVbqNicZSm7U5P+63TWlWELPKQAUMw170NnRwPo=
 github.com/quibbble/go-tsuro v1.0.9/go.mod h1:HKhhc+IZJjtw7T2zhVcZVD6Q2GVQOUd31AnIs9pBHHg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/internal/datastore/cockroach_client.go
+++ b/internal/datastore/cockroach_client.go
@@ -149,6 +149,9 @@ func (c *CockroachClient) Store(game *Game) error {
 		logger.Log.Error().Caller().Err(err).Msg("failed to exec on cockroach")
 		return ErrGameStoreInsert
 	}
+
+	logger.Log.Debug().Msgf("stored '%s' with id '%s' in game store", game.GameKey, game.GameID)
+
 	return nil
 }
 

--- a/internal/networking/error.go
+++ b/internal/networking/error.go
@@ -1,0 +1,59 @@
+package go_boardgame_networking
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrBGNUnsupported = func(gameKey string) error {
+		return fmt.Errorf("bgn is not supported for gameKey '%s'", gameKey)
+	}
+
+	ErrNoExistingGameKey = func(gameKey string) error {
+		return fmt.Errorf("gameKey does not exist for gameKey '%s'", gameKey)
+	}
+
+	ErrExistingGameID = func(gameKey, gameID string) error {
+		return fmt.Errorf("gameID '%s' already exists for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrNoExistingGameID = func(gameKey, gameID string) error {
+		return fmt.Errorf("gameID '%s' does not exist for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrCreateGame = func(gameKey, gameID string) error {
+		return fmt.Errorf("failed to create game with gameID '%s' for gameKey '%s'", gameID, gameKey)
+	}
+	ErrStoreGame = func(gameKey, gameID string) error {
+		return fmt.Errorf("failed to store game with gameID '%s' for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrHubClosure = func(gameKey ...string) error {
+		return fmt.Errorf("game hubs '%s' failed to close gracefully", strings.Join(gameKey, ", "))
+	}
+
+	ErrInconsistentTeams = func(gameKey, gameID string) error {
+		return fmt.Errorf("number of teams are inconsistent in gameID '%s' for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrCreateGameOptions = func(gameKey, gameID string) error {
+		return fmt.Errorf("invalid create game options in gameID '%s' for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrPlayerAlreadyConnected = func(gameKey, gameID string) error {
+		return fmt.Errorf("player already connected in gameID '%s' for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrPlayerUnauthorized = func(gameKey, gameID string) error {
+		return fmt.Errorf("player not authorized to join gameID '%s' for gameKey '%s'", gameID, gameKey)
+	}
+
+	ErrActionNotAllowed = func(actionType string) error {
+		return fmt.Errorf("%s action not allowed", actionType)
+	}
+
+	ErrNoActionToUndo = fmt.Errorf("no action to undo")
+
+	ErrWrongTeamAction = fmt.Errorf("cannot perform game action for another team")
+)

--- a/internal/networking/game_hub.go
+++ b/internal/networking/game_hub.go
@@ -2,7 +2,6 @@ package go_boardgame_networking
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -14,7 +13,7 @@ import (
 // gameHub is a hub for a unique game type i.e. only for connect4 or only for tsuro
 type gameHub struct {
 	gameStore  datastore.GameStore
-	builder    bg.BoardGameWithBGNBuilder
+	builder    bg.BoardGameBuilder
 	games      map[string]*gameServer // mapping from game ID to game server
 	cleanup    map[string]chan bool   // mapping from game ID to game's done channel that should be closed on game cleanup
 	create     chan CreateGameOptions
@@ -25,7 +24,7 @@ type gameHub struct {
 	adapters   []NetworkAdapter
 }
 
-func newGameHub(builder bg.BoardGameWithBGNBuilder, gameExpiry time.Duration, adapters []NetworkAdapter, gameStore datastore.GameStore) *gameHub {
+func newGameHub(builder bg.BoardGameBuilder, gameExpiry time.Duration, adapters []NetworkAdapter, gameStore datastore.GameStore) *gameHub {
 	return &gameHub{
 		gameStore:  gameStore,
 		builder:    builder,
@@ -41,38 +40,41 @@ func newGameHub(builder bg.BoardGameWithBGNBuilder, gameExpiry time.Duration, ad
 }
 
 func (h *gameHub) Start() {
+	gameKey := h.builder.Key()
+
 	// catch any panics and close the game out gracefully
 	// prevents the server from crashing due to bugs in a game
 	defer func() {
 		if r := recover(); r != nil {
-			msg := fmt.Sprintf("%v from game key '%s' with stack trace %s", r, h.builder.Key(), string(debug.Stack()))
-			logger.Log.Error().Caller().Msg(msg)
+			logger.Log.Error().Caller().Msgf("%v from game key '%s' with stack trace %s", r, h.builder.Key(), string(debug.Stack()))
 		}
 	}()
+
 	go h.clean()
 	for {
 		select {
 		case create := <-h.create:
-			_, ok := h.games[create.NetworkOptions.GameID]
+			gameID := create.NetworkOptions.GameID
+			_, ok := h.games[gameID]
 			if ok {
-				h.done <- fmt.Errorf("game id '%s' already exists", create.NetworkOptions.GameID)
+				h.done <- ErrExistingGameID(gameKey, gameID)
 				continue
 			}
 			server, err := newServer(h.builder, &create, h.adapters)
 			if err != nil {
-				logger.Log.Error().Err(err).Msgf("failed to create game '%s' with id '%s'", h.builder.Key(), create.NetworkOptions.GameID)
+				logger.Log.Error().Err(err).Msgf(ErrCreateGame(gameKey, gameID).Error())
 				h.done <- err
 				continue
 			}
 			cleanup := make(chan bool)
 			go server.Start(cleanup)
-			h.games[create.NetworkOptions.GameID] = server
-			h.cleanup[create.NetworkOptions.GameID] = cleanup
+			h.games[gameID] = server
+			h.cleanup[gameID] = cleanup
 			h.done <- nil
 		case join := <-h.join:
 			server, ok := h.games[join.GameID]
 			if !ok {
-				h.done <- fmt.Errorf("game id '%s' does not exist", join.GameID)
+				h.done <- ErrNoExistingGameID(gameKey, join.GameID)
 				continue
 			}
 			h.done <- server.Join(join)
@@ -102,27 +104,29 @@ func (h *gameHub) Join(options JoinGameOptions) error {
 }
 
 func (h *gameHub) clean() {
+	gameKey := h.builder.Key()
+
 	// every hour check if game is passed gameExpiry in which case it is removed
 	for range time.Tick(time.Minute) {
 		for gameID, server := range h.games {
 			deleteTime := server.updatedAt.Add(h.gameExpiry)
 			if time.Now().After(deleteTime) {
-				logger.Log.Debug().Msgf("cleaning '%s' with id '%s'", h.builder.Key(), gameID)
-
-				// only store games that were actually used
-				if len(server.game.GetBGN().Actions) > 0 || server.playCount > 0 {
+				bgnGame, ok := server.game.(bg.BoardGameWithBGN)
+				if !ok {
+					logger.Log.Error().Caller().Err(ErrBGNUnsupported(gameKey))
+				} else if len(bgnGame.GetBGN().Actions) > 0 || server.playCount > 0 {
 					if err := h.gameStore.Store(&datastore.Game{
-						GameKey:   h.builder.Key(),
+						GameKey:   gameKey,
 						GameID:    gameID,
-						BGN:       server.game.GetBGN(),
+						BGN:       bgnGame.GetBGN(),
 						CreatedAt: server.createdAt,
 						UpdatedAt: server.updatedAt,
 						PlayCount: server.playCount,
 					}); err != nil {
-						logger.Log.Error().Caller().Err(err).Msgf("failed to store '%s' with id '%s'", h.builder.Key(), gameID)
+						logger.Log.Error().Caller().Err(err).Msgf(ErrStoreGame(gameKey, gameID).Error())
 					}
 				}
-
+				logger.Log.Debug().Msgf("cleaning '%s' with id '%s'", h.builder.Key(), gameID)
 				h.close <- gameID
 			}
 		}
@@ -130,20 +134,25 @@ func (h *gameHub) clean() {
 }
 
 func (h *gameHub) Store(ctx context.Context) error {
+	gameKey := h.builder.Key()
+
+	if _, ok := h.builder.(bg.BoardGameWithBGNBuilder); !ok {
+		return ErrBGNUnsupported(gameKey)
+	}
 	for gameID, server := range h.games {
-		// don't store games that were never used
-		if len(server.game.GetBGN().Actions) <= 0 && server.playCount <= 0 {
+		bgnGame := server.game.(bg.BoardGameWithBGN)
+		if len(bgnGame.GetBGN().Actions) <= 0 && server.playCount <= 0 {
 			continue
 		}
 		if err := h.gameStore.Store(&datastore.Game{
-			GameKey:   h.builder.Key(),
+			GameKey:   gameKey,
 			GameID:    gameID,
-			BGN:       server.game.GetBGN(),
+			BGN:       bgnGame.GetBGN(),
 			CreatedAt: server.createdAt,
 			UpdatedAt: server.updatedAt,
 			PlayCount: server.playCount,
 		}); err != nil {
-			logger.Log.Error().Caller().Err(err).Msgf("failed to store '%s' with id '%s'", h.builder.Key(), gameID)
+			logger.Log.Error().Caller().Err(err).Msgf(ErrStoreGame(gameKey, gameID).Error())
 			return err
 		}
 	}

--- a/internal/networking/models.go
+++ b/internal/networking/models.go
@@ -13,13 +13,16 @@ import (
 // GameNetworkOptions are the options required to create a new network
 type GameNetworkOptions struct {
 	// Games is the list of game builders to add to the networking layer
-	Games []bg.BoardGameWithBGNBuilder
+	Games []bg.BoardGameBuilder
 
 	// Adapters allow for external events to be triggered on game start or end
 	Adapters []NetworkAdapter
 
 	// GameExpiry refers to how long after creation a game will last before being removed
 	GameExpiry time.Duration
+
+	// GameStore stores games longterm
+	GameStore datastore.GameStore
 }
 
 // CreateGameOptions are the fields necessary for creating a game

--- a/internal/server/games.go
+++ b/internal/server/games.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	bg "github.com/quibbble/go-boardgame"
-	tictactoe "github.com/quibbble/go-boardgame/examples/tictactoe"
 	carcassonne "github.com/quibbble/go-carcassonne"
 	connect4 "github.com/quibbble/go-connect4"
 	indigo "github.com/quibbble/go-indigo"
 	stratego "github.com/quibbble/go-stratego"
+	tictactoe "github.com/quibbble/go-tictactoe"
 	tsuro "github.com/quibbble/go-tsuro"
 )
 

--- a/internal/server/player_name.go
+++ b/internal/server/player_name.go
@@ -8,7 +8,7 @@ import (
 
 func generateName() string {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return fmt.Sprintf("%s-%s", adjectives[r.Intn(len(adjectives))], nouns[r.Intn(len(nouns))])
+	return fmt.Sprintf("%s-%s-%d", adjectives[r.Intn(len(adjectives))], nouns[r.Intn(len(nouns))], r.Intn(99))
 }
 
 var adjectives = []string{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,7 +23,7 @@ type Server struct {
 }
 
 func NewServer(cfg Config) (*Server, error) {
-	g := make([]bg.BoardGameWithBGNBuilder, 0)
+	g := make([]bg.BoardGameBuilder, 0)
 	a := make([]networking.NetworkAdapter, 0)
 	for _, game := range cfg.Network.Games {
 		g = append(g, games[game])
@@ -38,7 +38,8 @@ func NewServer(cfg Config) (*Server, error) {
 		Games:      g,
 		Adapters:   a,
 		GameExpiry: cfg.Network.GameExpiry,
-	}, gameStore)
+		GameStore:  gameStore,
+	})
 	handler := NewHandler(render.New(), network, gameStore)
 	r := NewRouter(cfg.Router)
 	r = AddRoutes(r, handler)


### PR DESCRIPTION
- Normal `bg.BoardGame`s can be used without implemention BGN. They will just not be stored or retrieved from the game store. 
- Tic-Tac-Toe has been moved to it's own go module.
- General code cleanup. 